### PR TITLE
[Add]DeviseBootstrapTemplate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "refile", require: "refile/rails", github: 'manfe/refile'
 gem "refile-mini_magick"
 gem 'devise'
+gem 'devise-bootstrap-views'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'jquery-rails'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-bootstrap-views (1.1.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
@@ -297,6 +298,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  devise-bootstrap-views
   dotenv-rails
   font-awesome-sass (~> 5.8.1)
   html2slim

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,0 +1,4 @@
+body {
+  padding-top: 70px;
+  padding-bottom: 30px;
+}

--- a/app/views/admins/devise/confirmations/new.html.slim
+++ b/app/views/admins/devise/confirmations/new.html.slim
@@ -1,0 +1,10 @@
+h1
+  = t('.resend_confirmation_instructions')
+= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: 'form-control'
+  .form-group
+    = f.submit t('.resend_confirmation_instructions'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/admins/devise/passwords/edit.html.slim
+++ b/app/views/admins/devise/passwords/edit.html.slim
@@ -1,0 +1,17 @@
+h1
+  = t('.change_your_password')
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = bootstrap_devise_error_messages!
+  = f.hidden_field :reset_password_token
+  .form-group
+    = f.label :password, t('.new_password')
+    = f.password_field :password, autofocus: true, class: 'form-control'
+    - if @minimum_password_length
+      small.form-text.text-muted
+        = t('devise.shared.minimum_password_length', count: @minimum_password_length)
+  .form-group
+    = f.label :password_confirmation, t('.confirm_new_password')
+    = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control'
+  .form-group
+    = f.submit t('.change_my_password'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/admins/devise/passwords/new.html.slim
+++ b/app/views/admins/devise/passwords/new.html.slim
@@ -1,0 +1,10 @@
+h1
+  = t('.forgot_your_password')
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.submit t('.send_me_reset_password_instructions'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/admins/devise/registrations/edit.html.slim
+++ b/app/views/admins/devise/registrations/edit.html.slim
@@ -1,0 +1,28 @@
+h1
+  = t('.title', resource: resource_name.to_s.humanize)
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.label :password
+    = f.password_field :password, autocomplete: 'new-password', class: 'form-control'
+    small.form-text.text-muted
+      = t('.leave_blank_if_you_don_t_want_to_change_it')
+  .form-group
+    = f.label :password_confirmation
+    = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control'
+  .form-group
+    = f.label :current_password
+    = f.password_field :current_password, autocomplete: 'current-password', class: 'form-control'
+    small.form-text.text-muted
+      = t('.we_need_your_current_password_to_confirm_your_changes')
+  .form-group
+    = f.submit t('.update'), class: 'btn btn-primary'
+p
+  = t('.unhappy')
+  | ? 
+  = link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete
+  | .
+= link_to t('.back'), :back

--- a/app/views/admins/devise/registrations/new.html.slim
+++ b/app/views/admins/devise/registrations/new.html.slim
@@ -1,0 +1,19 @@
+h1
+  = t('.sign_up')
+= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.label :password
+    = f.password_field :password, autocomplete: 'current-password', class: 'form-control'
+    - if @minimum_password_length
+      small.form-text.text-muted
+        = t('devise.shared.minimum_password_length', count: @minimum_password_length)
+  .form-group
+    = f.label :password_confirmation
+    = f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control'
+  .form-group
+    = f.submit t('.sign_up'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/admins/devise/sessions/new.html.slim
+++ b/app/views/admins/devise/sessions/new.html.slim
@@ -1,0 +1,17 @@
+h1
+  = t('.sign_in')
+= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.label :password
+    = f.password_field :password, autocomplete: 'current-password', class: 'form-control'
+  - if devise_mapping.rememberable?
+    .form-group.form-check
+      = f.check_box :remember_me, class: 'form-check-input'
+      = f.label :remember_me, class: 'form-check-label' do
+        = resource.class.human_attribute_name('remember_me')
+  .form-group
+    = f.submit  t('.sign_in'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/admins/devise/shared/_links.html.slim
+++ b/app/views/admins/devise/shared/_links.html.slim
@@ -1,0 +1,20 @@
+.form-group
+  - if controller_name != 'sessions'
+    = link_to t(".sign_in"), new_session_path(resource_name)
+    br
+  - if devise_mapping.registerable? && controller_name != 'registrations'
+    = link_to t(".sign_up"), new_registration_path(resource_name)
+    br
+  - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+    = link_to t(".forgot_your_password"), new_password_path(resource_name)
+    br
+  - if devise_mapping.confirmable? && controller_name != 'confirmations'
+    = link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name)
+    br
+  - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+    = link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name)
+    br
+  - if devise_mapping.omniauthable?
+    - resource_class.omniauth_providers.each do |provider|
+      = link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider)
+      br

--- a/app/views/admins/devise/unlocks/new.html.slim
+++ b/app/views/admins/devise/unlocks/new.html.slim
@@ -1,0 +1,10 @@
+h1
+  = t('.resend_unlock_instructions')
+= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.submit t('.resend_unlock_instructions'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,10 +2,36 @@ doctype html
 html
   head
     title
-      | Cocktails
+      | Jigger
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   body
-    = yield
+    nav.navbar.navbar-default.navbar-fixed-top
+      .container
+        .navbar-header
+          button.navbar-toggle.collapsed aria-controls="navbar" aria-expanded="false" data-target="#navbar" data-toggle="collapse" type="button"
+            span.sr-pnly Toggle navigation
+            span.icon-bar
+            span.icon-bar
+            span.icon-bar
+          = link_to 'Jigger', root_path, class: 'navbar-brand'
+        #navbar.navbar-collapse.collapse
+          ul.nav.navbar-nav
+            li = link_to 'リンク１', root_path
+            li = link_to 'リンク２', root_path
+            li = link_to 'リンク３', root_path
+          ul.nav.navbar-nav.navbar-right
+            -if end_user_signed_in?
+              li.dropdown
+                a.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#" role="button"
+                  = current_end_user.email
+                  span.caret
+                ul.dropdown-menu
+                  li = link_to 'ログアウト', destroy_end_user_session_path, method: :delete
+            -else
+              li = link_to 'ログイン', new_end_user_session_path
+
+    .container
+      = yield

--- a/app/views/public/devise/confirmations/new.html.slim
+++ b/app/views/public/devise/confirmations/new.html.slim
@@ -1,0 +1,10 @@
+h1
+  = t('.resend_confirmation_instructions')
+= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: 'form-control'
+  .form-group
+    = f.submit t('.resend_confirmation_instructions'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/public/devise/passwords/edit.html.slim
+++ b/app/views/public/devise/passwords/edit.html.slim
@@ -1,0 +1,17 @@
+h1
+  = t('.change_your_password')
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = bootstrap_devise_error_messages!
+  = f.hidden_field :reset_password_token
+  .form-group
+    = f.label :password, t('.new_password')
+    = f.password_field :password, autofocus: true, class: 'form-control'
+    - if @minimum_password_length
+      small.form-text.text-muted
+        = t('devise.shared.minimum_password_length', count: @minimum_password_length)
+  .form-group
+    = f.label :password_confirmation, t('.confirm_new_password')
+    = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control'
+  .form-group
+    = f.submit t('.change_my_password'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/public/devise/passwords/new.html.slim
+++ b/app/views/public/devise/passwords/new.html.slim
@@ -1,0 +1,10 @@
+h1
+  = t('.forgot_your_password')
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.submit t('.send_me_reset_password_instructions'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/public/devise/registrations/edit.html.slim
+++ b/app/views/public/devise/registrations/edit.html.slim
@@ -1,0 +1,28 @@
+h1
+  = t('.title', resource: resource_name.to_s.humanize)
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.label :password
+    = f.password_field :password, autocomplete: 'new-password', class: 'form-control'
+    small.form-text.text-muted
+      = t('.leave_blank_if_you_don_t_want_to_change_it')
+  .form-group
+    = f.label :password_confirmation
+    = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control'
+  .form-group
+    = f.label :current_password
+    = f.password_field :current_password, autocomplete: 'current-password', class: 'form-control'
+    small.form-text.text-muted
+      = t('.we_need_your_current_password_to_confirm_your_changes')
+  .form-group
+    = f.submit t('.update'), class: 'btn btn-primary'
+p
+  = t('.unhappy')
+  | ? 
+  = link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete
+  | .
+= link_to t('.back'), :back

--- a/app/views/public/devise/registrations/new.html.slim
+++ b/app/views/public/devise/registrations/new.html.slim
@@ -1,0 +1,19 @@
+h1
+  = t('.sign_up')
+= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.label :password
+    = f.password_field :password, autocomplete: 'current-password', class: 'form-control'
+    - if @minimum_password_length
+      small.form-text.text-muted
+        = t('devise.shared.minimum_password_length', count: @minimum_password_length)
+  .form-group
+    = f.label :password_confirmation
+    = f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control'
+  .form-group
+    = f.submit t('.sign_up'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/public/devise/sessions/new.html.slim
+++ b/app/views/public/devise/sessions/new.html.slim
@@ -1,0 +1,17 @@
+h1
+  = t('.sign_in')
+= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.label :password
+    = f.password_field :password, autocomplete: 'current-password', class: 'form-control'
+  - if devise_mapping.rememberable?
+    .form-group.form-check
+      = f.check_box :remember_me, class: 'form-check-input'
+      = f.label :remember_me, class: 'form-check-label' do
+        = resource.class.human_attribute_name('remember_me')
+  .form-group
+    = f.submit  t('.sign_in'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/public/devise/shared/_links.html.slim
+++ b/app/views/public/devise/shared/_links.html.slim
@@ -1,0 +1,20 @@
+.form-group
+  - if controller_name != 'sessions'
+    = link_to t(".sign_in"), new_session_path(resource_name)
+    br
+  - if devise_mapping.registerable? && controller_name != 'registrations'
+    = link_to t(".sign_up"), new_registration_path(resource_name)
+    br
+  - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+    = link_to t(".forgot_your_password"), new_password_path(resource_name)
+    br
+  - if devise_mapping.confirmable? && controller_name != 'confirmations'
+    = link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name)
+    br
+  - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+    = link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name)
+    br
+  - if devise_mapping.omniauthable?
+    - resource_class.omniauth_providers.each do |provider|
+      = link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider)
+      br

--- a/app/views/public/devise/unlocks/new.html.slim
+++ b/app/views/public/devise/unlocks/new.html.slim
@@ -1,0 +1,10 @@
+h1
+  = t('.resend_unlock_instructions')
+= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = bootstrap_devise_error_messages!
+  .form-group
+    = f.label :email
+    = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'
+  .form-group
+    = f.submit t('.resend_unlock_instructions'), class: 'btn btn-primary'
+= render 'devise/shared/links'

--- a/app/views/public/homes/top.html.slim
+++ b/app/views/public/homes/top.html.slim
@@ -3,3 +3,6 @@ h1
 p
   | Find me in app/views/public/homes/top.html.erb
 = link_to 'ABOUT', public_end_user_about_path, class: 'btn btn-info'
+
+= link_to 'Log out', destroy_end_user_session_path, class: 'btn btn-danger', method: :delete
+= link_to 'Sign up', new_end_user_registration_path, class: 'btn btn-success'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root 'public/homes#top'
+
   # EndUser側ルーティング
   devise_scope :public do
     devise_for :end_users, controllers: {


### PR DESCRIPTION
DeviseのビューレイアウトをBootstrap化するため、gem 'devise-bootstrap-views'を追加。
Deviseのビューをpublicとdeviseで分けて管理。
erb2slimを実行し、ビューファイルをslim化。
アプリ独自のスタイルをcommon.scssに定義。