### PR TITLE
Feature/similar cocktail

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,10 +28,10 @@ jQuery(function() {
 		loader.fadeOut();
 	});
 
-	//ページの読み込みが完了してなくても4秒後にアニメーションを非表示にする
+	//ページの読み込みが完了してなくても3秒後にアニメーションを非表示にする
 	setTimeout(function() {
 		loader.fadeOut();
-	},4000);
+	},3000);
 });
 
 // MyPage-Tabbutton

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -66,7 +66,7 @@ footer {
 
 // Cocktails masonry
 .masonry {
-  columns: 5;
+  columns: 4;
   column-gap: 16px;
   @media (max-width: 1200px) {
     columns: 3;
@@ -175,7 +175,7 @@ footer {
   text-align: center;
   }
 
-  //  Loading-animation
+//  Loading-animation
 .loader-wrap {
   position: fixed;
   display: flex;

--- a/app/controllers/public/cocktails_controller.rb
+++ b/app/controllers/public/cocktails_controller.rb
@@ -36,6 +36,16 @@ class Public::CocktailsController < ApplicationController
   end
 
   def show
+    similar_table = Similar.where(cocktail1: @cocktail.id).or(Similar.where(cocktail2: @cocktail.id)).order("value DESC").limit(3).pluck(:cocktail1,:cocktail2)
+    @similar_cocktails = []
+    similar_table.each do |ids|
+      ids.each do |id|
+        unless id == @cocktail.id
+          similar_cocktail = Cocktail.find(id)
+          @similar_cocktails.push(similar_cocktail)
+        end
+      end
+    end
   end
 
   def new

--- a/app/models/similar.rb
+++ b/app/models/similar.rb
@@ -1,0 +1,2 @@
+class Similar < ApplicationRecord
+end

--- a/app/views/admins/cocktails/show.html.slim
+++ b/app/views/admins/cocktails/show.html.slim
@@ -33,8 +33,7 @@
           th = @cocktail.tpo_name
     .row
       .col-9
-        h2
-          | How to Make
+        h2 How to Make
         h4
           br
           = @cocktail.recipe_desc
@@ -57,3 +56,26 @@
         = link_to  admins_end_user_path(@cocktail.end_user_id)
           = attachment_image_tag @cocktail.end_user, :image, format: 'jpeg', class: "img-raised rounded-circle img-responsive", fallback: "no_image.png"
           h4 = @cocktail.end_user.name
+
+    .row
+      .col-10
+        - if @similar_cocktails.presence
+          h4 似ているカクテル（類似度順）
+          table.table
+            thead
+              tr
+                th Name
+                th Base
+                th Taste
+                th Style
+                th Alcohol
+            tbody
+              - @similar_cocktails.each do |cocktail|
+                tr
+                  th = link_to cocktail.name, admins_cocktail_path(cocktail.id)
+                  th = cocktail.base_name
+                  th = cocktail.taste_name
+                  th = cocktail.style_name
+                  th
+                    = cocktail.alcohol
+                    | %

--- a/app/views/admins/homes/top.html.slim
+++ b/app/views/admins/homes/top.html.slim
@@ -31,3 +31,4 @@ br
 
 = link_to "API cocktail GET", get_api_cocktails_admins_cocktails_path, class:"btn btn-primary"
 = link_to "Cocktail Image GET", get_cocktail_image_admins_cocktails_path, class:"btn btn-info"
+= link_to "SimilarCocktail", similar_cocktail_admins_cocktails_path, class:"btn btn-primary"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -47,7 +47,7 @@ html
               .nav-link = link_to '新規登録', new_end_user_registration_path
 
             = form_with url: search_path, class:"form-inline ml-auto",local: true , method: :get do |f|
-              = f.text_field :content ,class:"form-control mr-sm-2", placeholder:"カクテル名・材料名"
+              = f.text_field :content ,class:"form-control", placeholder:"カクテル名・材料名"
               = f.button :type => "submit", class:"btn btn-white btn-raised btn-fab btn-round"
                 = icon('fas', 'search')
 

--- a/app/views/public/cocktails/show.html.slim
+++ b/app/views/public/cocktails/show.html.slim
@@ -30,7 +30,9 @@
           th = @cocktail.technique_name
           th = @cocktail.taste_name
           th = @cocktail.style_name
-          th = @cocktail.alcohol
+          th
+           = @cocktail.alcohol
+           |  %
           th = @cocktail.tpo_name
 
     .row

--- a/app/views/public/cocktails/show.html.slim
+++ b/app/views/public/cocktails/show.html.slim
@@ -60,3 +60,26 @@
         = link_to  public_end_user_path(@cocktail.end_user_id)
           = attachment_image_tag @cocktail.end_user, :image, format: 'jpeg', class: "img-raised rounded-circle img-responsive", fallback: "no_image.png"
           h4 = @cocktail.end_user.name
+    
+    .row
+      .col-12
+        - if @similar_cocktails.presence
+          h4 似ているカクテル（類似度順：ユーザーのお気に入りデータを元に算出）
+          .row
+            - @similar_cocktails.each do |cocktail|
+              .col-4
+                = link_to public_cocktail_path(cocktail.id)
+                  .card.mb-3 style="max-width: 500px"
+                    .row.no-gutters
+                      .col-md-5
+                        - if cocktail.image_id.nil? || cocktail.image_id.exclude?("http")
+                          = attachment_image_tag cocktail, :image, fallback:"default.jpeg", class:"rounded card-img cocktail-img"
+                        - else
+                          img.cocktail-img src="#{cocktail.image_id}" alt="img" class="rounded card-img" width="130px" height="170px"
+                      .col-md-7
+                        .card-body
+                          h5.card-title = cocktail.name
+                          p.card-text = "Base:#{cocktail.base_name}"
+                          p.card-text = "Taste:#{cocktail.taste_name}"
+                          p.card-text = "Style:#{cocktail.style_name}"
+                          p.card-text = "Alcohol:#{cocktail.alcohol}%"

--- a/app/views/search/search.html.slim
+++ b/app/views/search/search.html.slim
@@ -1,2 +1,0 @@
-h1 Search#search
-p Find me in app/views/search/search.html.slim

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
         get :get_api_cocktails
         get :get_cocktail_image
         post :search
+        get :similar_cocktail
       end
     end
     resources :ingredients, only: [:index, :create, :destroy] do

--- a/db/migrate/20200909004108_create_similars.rb
+++ b/db/migrate/20200909004108_create_similars.rb
@@ -1,0 +1,11 @@
+class CreateSimilars < ActiveRecord::Migration[5.2]
+  def change
+    create_table :similars do |t|
+      t.integer :cocktail1
+      t.integer :cocktail2
+      t.float :value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_064825) do
+ActiveRecord::Schema.define(version: 2020_09_09_004108) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -99,6 +99,14 @@ ActiveRecord::Schema.define(version: 2020_08_31_064825) do
   create_table "relationships", force: :cascade do |t|
     t.integer "follower_id", null: false
     t.integer "following_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "similars", force: :cascade do |t|
+    t.integer "cocktail1"
+    t.integer "cocktail2"
+    t.float "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds/end_user.rb
+++ b/db/seeds/end_user.rb
@@ -8,17 +8,34 @@ EndUser.create!(
     },
 
     {
-      name: 'second',
+      name: 'A',
       birth_date: '2005-12-13',
-      email: '2@2',
-      password: '222222',
+      email: 'a@a',
+      password: 'aaaaaa',
     },
-
     {
-      name: 'third',
+      name: 'B',
       birth_date: '1991-11-05',
-      email: '3@3',
-      password: '333333',
+      email: 'b@b',
+      password: 'bbbbbb',
+    },
+    {
+      name: 'C',
+      birth_date: '1991-11-05',
+      email: 'c@c',
+      password: 'cccccc',
+    },
+    {
+      name: 'D',
+      birth_date: '1991-11-05',
+      email: 'd@d',
+      password: 'dddddd',
+    },
+    {
+      name: 'E',
+      birth_date: '1991-11-05',
+      email: 'e@e',
+      password: 'eeeeee',
     },
   ]
 )

--- a/test/fixtures/similars.yml
+++ b/test/fixtures/similars.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  cocktail1: 1
+  cocktail2: 1
+  value: 1.5
+
+two:
+  cocktail1: 1
+  cocktail2: 1
+  value: 1.5

--- a/test/models/similar_test.rb
+++ b/test/models/similar_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SimilarTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
**カクテル同士の類似度算出**
-Admin側トップページにあるボタンからsimilar_cocktailメソッドを起動
 1.Favoriteテーブルから、各カクテル毎の集団ベクトルマトリクスを作成(favorite_matrix)
 2.favorite_matrixテーブルを正規化
 3.組み合わせごとのコサイン類似度（ベクトルの内積）を出力
 4.similarテーブルにカクテル同士の類似度を保存

-Admin側、Public側のカクテル詳細ページにて、類似度が高い順で3つ表示させる