### PR TITLE
レシピ投稿時の材料登録をテキスト入力に変更

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -135,9 +135,11 @@ footer {
   object-fit: cover;
   border-radius: 10px;
 }
-
 .tab-content {
   width: 100%;
+}
+table {
+  font-size: 14px;
 }
 // ---------------------
 

--- a/app/controllers/public/cocktails_controller.rb
+++ b/app/controllers/public/cocktails_controller.rb
@@ -111,7 +111,6 @@ class Public::CocktailsController < ApplicationController
   end
 
   def update
-    @cocktail.ingredient_relations.destroy_all
     if @cocktail.update(cocktail_params)
       flash[:notice] = "カクテル情報を変更しました"
       redirect_to public_cocktail_path(@cocktail)

--- a/app/controllers/public/cocktails_controller.rb
+++ b/app/controllers/public/cocktails_controller.rb
@@ -84,6 +84,20 @@ class Public::CocktailsController < ApplicationController
     @cocktail = Cocktail.new(cocktail_params)
     @cocktail.end_user_id = @end_user.id
 
+    # 送信された材料名からDBを検索しIDを返す。登録されてなければ新規に登録する
+    @cocktail.ingredient_relations.zip(cocktail_params[:ingredient_relations_attributes].values) do |i,j|
+      if Ingredient.find_by(name: j[:ingredient_id]).presence
+        i.ingredient_id = Ingredient.find_by(name: j[:ingredient_id]).id
+      else
+        new_ingredient = Ingredient.new
+        new_ingredient.name = j[:ingredient_id]
+        new_ingredient.type_name = "副材料"
+        new_ingredient.alcohol = 0
+        new_ingredient.save
+        i.ingredient_id = Ingredient.find_by(name: j[:ingredient_id]).id
+      end
+    end
+
     # トップに登録された材料をベースとしてCocktailテーブルに登録
     base_id = @cocktail.ingredient_relations[0].ingredient_id
     @cocktail.base_name = Ingredient.find_by(id: base_id).name

--- a/app/views/public/cocktails/_ingredient_relation_fields.html.slim
+++ b/app/views/public/cocktails/_ingredient_relation_fields.html.slim
@@ -1,11 +1,8 @@
 tr.nested-fields
-    th = f.select :ingredient_id, Ingredient.all.map {|ingredient| [ingredient.name, ingredient.id]}, include_blank: true
-
-    / 材料選択をテキスト入力で入力補完する方法を模索中
-    / th = f.text_field :ingredient_id, list: 'ingredient-list'
-    / datalist id='ingredient-list'
-    /  - Ingredient.all.map{|ingredient| [ingredient.name, ingredient.id]}.each do |i|
-    /     option label="#{i[0]}" value="#{i[1]}"
+    th = f.text_field :ingredient_id, list: 'ingredient-list'
+    datalist id='ingredient-list'
+     - Ingredient.all.map{|ingredient| [ingredient.name, ingredient.id]}.each do |i|
+        option value="#{i[0]}"
 
     th = f.number_field :amount, min: '0'
     th = f.select :unit, options_for_select(IngredientRelation.units.keys), class: 'form-control'

--- a/app/views/public/cocktails/edit.html.slim
+++ b/app/views/public/cocktails/edit.html.slim
@@ -1,8 +1,9 @@
+ .container
   .card.card-nav-tabs.text-center
     .card-header.card-header-primary
       h5 マイレシピ編集
     .card-body
-      .card-title.text-muted キャッチコピーは入力しなくても投稿可能です
+      .card-title.text-muted キャッチコピーは入力しなくても保存可能です
       = form_with model:[:public,@cocktail], local: true do |f|
         = render 'shared/error_messages', model: f.object
         .row
@@ -27,10 +28,11 @@
                   th 単位
                   th 
               tbody.line-ingredients
-                = f.fields_for :ingredient_relations do |ff|
-                  = render 'ingredient_relation_fields', f: ff
-            .links
-              = link_to_add_association '＋別の材料を追加', f, :ingredient_relations, data:{"association-insertion-node" => "tbody.line-ingredients", "association-insertion-method" => "append"}
+                - @cocktail.ingredient_relations.each do |ingredient_relation|
+                  tr
+                    th = ingredient_relation.ingredient.name
+                    th = ingredient_relation.amount
+                    th = ingredient_relation.unit
               
             .row
               label How to Make


### PR DESCRIPTION
投稿時のレシピ登録をテキスト入力に変更し、キーワードで入力候補リストを出力。
登録されていない材料の場合は新規に登録する。
レシピ編集画面では、材料の編集が出来ないように変更。
