### PR TITLE
お問い合わせ機能修正

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -4,6 +4,6 @@ class ContactMailer < ApplicationMailer
 
   def contact_mail(contact)
     @contact = contact
-    mail to: ENV['MAIL'], subject: "お問い合わせ通知"
+    mail to: ENV['ADMIN_mail'], subject: "お問い合わせ通知"
   end
 end

--- a/app/views/contact_mailer/contact_mail.html.slim
+++ b/app/views/contact_mailer/contact_mail.html.slim
@@ -1,7 +1,10 @@
-h3 お問い合わせ内容
-
+h3 お問い合わせ内容(jigger.work)
+br
 | --------------------------
-p email: = @contact.email
+p email:
+= @contact.email
 
-p content: = @contact.message
+p content:
+= @contact.message
+br
 | --------------------------

--- a/app/views/contacts/index.html.slim
+++ b/app/views/contacts/index.html.slim
@@ -18,4 +18,4 @@
               = f.text_area :message, placeholder: "500文字以内", class:"form-control"
               
           .footer.text-center
-            = f.submit '送信する', class:"btn btn-primary btn-link"
+            = f.submit '確認する', class:"btn btn-primary btn-link"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,9 +31,9 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { address: '127.0.0.1', port: 1025 }
+  # config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.delivery_method = :smtp
+  # config.action_mailer.smtp_settings = { address: '127.0.0.1', port: 1025 }
 
   config.action_mailer.perform_caching = false
 
@@ -60,4 +60,14 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    user_name: ENV['ADMIN_mail'],
+    password: ENV['MAIL_pass'],
+    authentication: 'plain',
+    enable_starttls_auto: true
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address: "smtp.gmail.com",
     port: 587,
-    user_name: ENV['MAIL'],
+    user_name: ENV['ADMIN_mail'],
     password: ENV['MAIL_pass'],
     authentication: 'plain',
     enable_starttls_auto: true


### PR DESCRIPTION
ENV['MAIL']だと何故かメールアドレスを認識しなかった為、ADMIN_mailに名前を変更した所開発環境でのメール送信に成功。